### PR TITLE
Fix Mongoose strictQuery deprecation warning

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -1,5 +1,8 @@
 const mongoose = require('mongoose');
 
+// Set strictQuery to suppress deprecation warning
+mongoose.set('strictQuery', true);
+
 const connectDB = async () => {
   try {
     await mongoose.connect(process.env.MONGODB_URI, {


### PR DESCRIPTION
Fix Mongoose strictQuery deprecation warning by updating config.db